### PR TITLE
Fix/hck 4385 Fix fetching indexes and mapping PK columns

### DIFF
--- a/reverse_engineering/helpers/cockroachDBHelpers/tableHelper.js
+++ b/reverse_engineering/helpers/cockroachDBHelpers/tableHelper.js
@@ -248,8 +248,8 @@ const mapIndexColumns = indexData => {
 				return;
 			}
 
-			const sortOrder = _.get(indexData, `ascendings.${itemIndex}`, false) ? 'ASC' : 'DESC';
-			const nullsOrder = getNullsOrder(_.get(indexData, `nulls_first.${itemIndex}`));
+			const sortOrder = _.get(indexData, `ascendings.${itemIndex}`, 'ASC');
+			const nullsOrder = _.get(indexData, `nulls_first.${itemIndex}`, 'NULLS FIRST');
 			const opclass = _.get(indexData, `opclasses.${itemIndex}`, '');
 			const collation = _.get(indexData, `collations.${itemIndex}`, '');
 
@@ -263,14 +263,6 @@ const mapIndexColumns = indexData => {
 		})
 		.compact()
 		.value();
-};
-
-const getNullsOrder = nulls_first => {
-	if (_.isNil(nulls_first)) {
-		return '';
-	}
-
-	return nulls_first ? 'NULLS FIRST' : 'NULLS LAST';
 };
 
 const getIndexStorageParameters = storageParameters => {

--- a/reverse_engineering/helpers/cockroachDBService.js
+++ b/reverse_engineering/helpers/cockroachDBService.js
@@ -257,7 +257,7 @@ module.exports = {
 		const tableColumns = await this._getTableColumns(tableName, schemaName, tableOid);
 		const descriptionResult = await db.queryTolerant(queryConstants.GET_DESCRIPTION_BY_OID, [tableOid], true);
 		const tableConstraintsResult = await db.queryTolerant(queryConstants.GET_TABLE_CONSTRAINTS, [tableOid]);
-		const tableIndexesResult = await db.queryTolerant(getGetIndexesQuery(version), [tableOid]);
+		const tableIndexesResult = await db.queryTolerant(queryConstants.GET_TABLE_INDEXES, [tableOid]);
 		const tableForeignKeys = await db.queryTolerant(queryConstants.GET_TABLE_FOREIGN_KEYS, [tableOid]);
 
 		logger.info('Table data retrieved', {
@@ -411,16 +411,6 @@ const isSystemSchema = schema_name => {
 	}
 
 	return false;
-};
-
-const getGetIndexesQuery = postgresVersion => {
-	if (postgresVersion === 10) {
-		return queryConstants.GET_TABLE_INDEXES_V_10;
-	} else if (postgresVersion > 15) {
-		return queryConstants.GET_TABLE_INDEXES_V_15;
-	} else {
-		return queryConstants.GET_TABLE_INDEXES;
-	}
 };
 
 const getGetFunctionsAdditionalDataQuery = postgreVersion => {

--- a/reverse_engineering/helpers/cockroachDBService.js
+++ b/reverse_engineering/helpers/cockroachDBService.js
@@ -315,6 +315,7 @@ module.exports = {
 		return _.map(tableColumns, columnData => {
 			return {
 				...columnData,
+				ordinal_position: Number(columnData.ordinal_position),
 				...(_.find(tableColumnsAdditionalData, { name: columnData.column_name }) || {}),
 			};
 		});


### PR DESCRIPTION
# Affected Paths

- `reverse_engineering/helpers/cockroachDBHelpers/columnHelper.js` - Column mapping is done in a very stupid and confusing way, rewrote it to only contain mappers and checkers. Added mapping of strings' "length" attribute to Numbers
- `reverse_engineering/helpers/cockroachDBHelpers/tableHelper.js` - Changed parsing of "Nulls first" and "ascending" index properties due to adjusting the query to work with CockroachDB catalogs
- `reverse_engineering/helpers/cockroachDBService.js` Fixed picking of the query that gets the information about indexes
- `reverse_engineering/helpers/queryConstants.js` Rewrote the query that retrieves info about indexes