### PR TITLE
Fix/hck 4386 integer subtype improvements

### DIFF
--- a/forward_engineering/configs/descriptors.js
+++ b/forward_engineering/configs/descriptors.js
@@ -1,3 +1,6 @@
+// The keys of the exported object indicate which types are allowed in this target
+// The values are deprecated configs and they are unnecessary to write
+
 module.exports = {
 	char: {
 		size: 1,
@@ -218,6 +221,11 @@ module.exports = {
 	jsonb: {
 		format: 'semi-structured',
 	},
+	int: {},
+	int2: {},
+	int4: {},
+	decimal: {},
+	float: {},
 	composite: {
 		format: 'semi-structured',
 		mode: 'object',

--- a/forward_engineering/ddlProvider/ddlHelpers/columnDefinitionHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/columnDefinitionHelper.js
@@ -45,9 +45,9 @@ module.exports = ({ _, assignTemplates, templates, commentIfDeactivated, wrapCom
 	};
 
 	const canHaveLength = type => ['char', 'varchar', 'bit', 'varbit'].includes(type);
-	const canHavePrecision = type => type === 'numeric';
+	const canHavePrecision = type => ['numeric', 'decimal'].includes(type);
 	const canHaveTimePrecision = type => ['time', 'timestamp'].includes(type);
-	const canHaveScale = type => type === 'numeric';
+	const canHaveScale = type => ['numeric', 'decimal'].includes(type);
 	const canHaveTypeModifier = type => ['geography', 'geometry'].includes(type);
 
 	const decorateType = (type, columnDefinition) => {

--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -82,7 +82,7 @@
 					"mode": "decimal"
 				},
 				"to": {
-					"mode": "numeric"
+					"mode": "decimal"
 				}
 			},
 			{
@@ -90,7 +90,7 @@
 					"mode": "dec"
 				},
 				"to": {
-					"mode": "numeric"
+					"mode": "decimal"
 				}
 			},
 			{
@@ -98,7 +98,95 @@
 					"mode": "fixed"
 				},
 				"to": {
+					"mode": "decimal"
+				}
+			},
+			{
+				"from": {
 					"mode": "numeric"
+				},
+				"to": {
+					"mode": "decimal"
+				}
+			},
+			{
+				"from": {
+					"mode": "mediumint"
+				},
+				"to": {
+					"mode": "int4"
+				}
+			},
+			{
+				"from": {
+					"mode": "int8"
+				},
+				"to": {
+					"mode": "int2"
+				}
+			},
+			{
+				"from": {
+					"mode": "int16"
+				},
+				"to": {
+					"mode": "int2"
+				}
+			},
+			{
+				"from": {
+					"mode": "int32"
+				},
+				"to": {
+					"mode": "int4"
+				}
+			},
+			{
+				"from": {
+					"mode": "int64"
+				},
+				"to": {
+					"mode": "int"
+				}
+			},
+			{
+				"from": {
+					"mode": "int96"
+				},
+				"to": {
+					"mode": "decimal"
+				}
+			},
+			{
+				"from": {
+					"mode": "smallint"
+				},
+				"to": {
+					"mode": "int2"
+				}
+			},
+			{
+				"from": {
+					"mode": "tinyint"
+				},
+				"to": {
+					"mode": "int2"
+				}
+			},
+			{
+				"from": {
+					"mode": "byteint"
+				},
+				"to": {
+					"mode": "int2"
+				}
+			},
+			{
+				"from": {
+					"mode": "bigint"
+				},
+				"to": {
+					"mode": "int"
 				}
 			},
 			{
@@ -106,7 +194,7 @@
 					"mode": "long"
 				},
 				"to": {
-					"mode": "bigint"
+					"mode": "int"
 				}
 			},
 			{

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2016-2023 by IntegrIT S.A. dba Hackolade.  All rights reserved.
+ *
+ * The copyright to the computer software herein is the property of IntegrIT S.A.
+ * The software may be used and/or copied only with the written permission of
+ * IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+ * the agreement/contract under which the software has been supplied.
+ *
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ */
+ {
+    "modify": {
+        "field": [
+            {
+				"from": {
+					"type": "numeric",
+					"mode": "int"
+				},
+				"to": {
+					"type": "numeric",
+					"childType": "integer",
+					"mode": "bigint"
+				}
+			}
+        ]
+    }
+}

--- a/reverse_engineering/helpers/cockroachDBHelpers/columnHelper.js
+++ b/reverse_engineering/helpers/cockroachDBHelpers/columnHelper.js
@@ -93,23 +93,28 @@ const getArrayType = (userDefinedTypes, column) => {
 
 const mapType = (userDefinedTypes, type) => {
 	switch (type) {
-		case 'bigint':
 		case 'bigserial':
-		case 'smallint':
-		case 'integer':
-		case 'numeric':
 		case 'real':
 		case 'double precision':
 		case 'smallserial':
 		case 'serial':
 		case 'money':
 			return { type: 'numeric', mode: type };
-		case 'int8':
-			return { type: 'numeric', mode: 'bigint' };
+		case 'numeric':
+		case 'dec':
+		case 'decimal':
+			return { type: 'numeric', mode: 'decimal' };
 		case 'int2':
-			return { type: 'numeric', mode: 'smallint' };
+		case 'smallint':
+			return { type: 'numeric', mode: 'int2' };
 		case 'int4':
-			return { type: 'numeric', mode: 'integer' };
+		case 'integer':
+			return { type: 'numeric', mode: 'int4' };
+		case 'int':
+		case 'int8':
+		case 'int64':
+		case 'bigint':
+			return { type: 'numeric', mode: 'int' };
 		case 'float4':
 			return { type: 'numeric', mode: 'real' };
 		case 'float8':

--- a/types/numeric.json
+++ b/types/numeric.json
@@ -28,27 +28,15 @@
 	"descriptor": [
 		{
 			"schema": {
-				"mode": "int2"
-			},
-			"mode": "smallint"
-		},
-		{
-			"schema": {
-				"mode": "integer"
-			},
-			"capacity": 4
-		},
-		{
-			"schema": {
-				"mode": "integer"
-			},
-			"mode": "integer"
-		},
-		{
-			"schema": {
 				"mode": "int"
 			},
 			"capacity": 8
+		},
+		{
+			"schema": {
+				"mode": "int2"
+			},
+			"mode": "smallint"
 		},
 		{
 			"schema": {
@@ -61,6 +49,18 @@
 				"mode": "int4"
 			},
 			"capacity": 4
+		},
+		{
+			"schema": {
+				"mode": "int4"
+			},
+			"mode": "integer"
+		},
+		{
+			"schema": {
+				"mode": "int4"
+			},
+			"mode": "int"
 		},
 		{
 			"schema": {
@@ -79,18 +79,6 @@
 				"mode": "int"
 			},
 			"mode": "bigint"
-		},
-		{
-			"schema": {
-				"mode": "int"
-			},
-			"mode": "integer"
-		},
-		{
-			"schema": {
-				"mode": "int64"
-			},
-			"mode": "integer"
 		},
 		{
 			"schema": {
@@ -114,28 +102,28 @@
 		},
 		{
 			"schema": {
-				"mode": "smallserial"
+				"mode": "int2"
 			},
 			"capacity": 2,
 			"mode": "serial"
 		},
 		{
 			"schema": {
-				"mode": "serial"
+				"mode": "int4"
 			},
 			"capacity": 4,
 			"mode": "serial"
 		},
 		{
 			"schema": {
-				"mode": "bigserial"
+				"mode": "int"
 			},
 			"capacity": 8,
 			"mode": "serial"
 		},
 		{
 			"schema": {
-				"mode": "money"
+				"mode": "decimal"
 			},
 			"capacity": 8,
 			"mode": "decimal"

--- a/types/numeric.json
+++ b/types/numeric.json
@@ -101,6 +101,18 @@
 		},
 		{
 			"schema": {
+				"mode": "int64"
+			},
+			"mode": "integer"
+		},
+		{
+			"schema": {
+				"mode": "dec"
+			},
+			"mode": "decimal"
+		},
+		{
+			"schema": {
 				"mode": "real"
 			},
 			"capacity": 4,

--- a/types/numeric.json
+++ b/types/numeric.json
@@ -28,13 +28,7 @@
 	"descriptor": [
 		{
 			"schema": {
-				"mode": "smallint"
-			},
-			"capacity": 2
-		},
-		{
-			"schema": {
-				"mode": "smallint"
+				"mode": "int2"
 			},
 			"mode": "smallint"
 		},
@@ -52,16 +46,9 @@
 		},
 		{
 			"schema": {
-				"mode": "bigint"
+				"mode": "int"
 			},
 			"capacity": 8
-		},
-		{
-			"schema": {
-				"mode": "numeric"
-			},
-			"capacity": 12,
-			"mode": "decimal"
 		},
 		{
 			"schema": {
@@ -91,7 +78,7 @@
 			"schema": {
 				"mode": "int"
 			},
-			"capacity": 4
+			"mode": "bigint"
 		},
 		{
 			"schema": {

--- a/types/numeric.json
+++ b/types/numeric.json
@@ -65,6 +65,42 @@
 		},
 		{
 			"schema": {
+				"mode": "int2"
+			},
+			"capacity": 2
+		},
+		{
+			"schema": {
+				"mode": "int4"
+			},
+			"capacity": 4
+		},
+		{
+			"schema": {
+				"mode": "decimal"
+			},
+			"mode": "decimal"
+		},
+		{
+			"schema": {
+				"mode": "float"
+			},
+			"mode": "float"
+		},
+		{
+			"schema": {
+				"mode": "int"
+			},
+			"capacity": 4
+		},
+		{
+			"schema": {
+				"mode": "int"
+			},
+			"mode": "integer"
+		},
+		{
+			"schema": {
 				"mode": "real"
 			},
 			"capacity": 4,


### PR DESCRIPTION
## Content

Added support for CockroachDB-specific data types. Fixed descriptors to not use types that do not exist in CockroachDB.

## Affected Paths

- `forward_engineering/configs/descriptors.js` Added list of allowed subtypes
- 'forward_engineering/ddlProvider/ddlHelpers/columnDefinitionHelper.js' fixed issue with reverse-engineering DECIMAL type with precision and scale
- `polyglot/adapter.json` Added adapters to correctly map types from Polyglot
- `polyglot/convertAdapter.json` Added adapters to correctly map types to Polyglot
- `reverse_engineering/helpers/cockroachDBHelpers/columnHelper.js` Added type mappings for CockroachDB specific types
- `types/numeric.json` Added numeric type descriptors