### PR TITLE
HCK-8740: Add composite PK/UK to FE

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -240,6 +240,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -478,6 +479,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -736,6 +738,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -974,6 +977,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -1204,6 +1208,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -1442,6 +1447,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -1711,6 +1717,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -1949,6 +1956,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -2245,6 +2253,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -2483,6 +2492,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -2699,6 +2709,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -2937,6 +2948,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",
@@ -3174,6 +3186,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Primary key",
 				"propertyKeyword": "compositePrimaryKey",
+				"propertyNameFull": "Composite Primary Key",
 				"propertyType": "checkbox",
 				"propertyTooltip": {
 					"disabled": [
@@ -3412,6 +3425,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "compositeUniqueKey",
+				"propertyNameFull": "Composite Unique Key",
 				"propertyType": "checkbox",
 				"dependency": {
 					"key": "compositeUniqueKey",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8740" title="HCK-8740" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-8740</a>  Excel. Include 'Composite Primary Key' and 'Composite Unique Key' in export to Excel for supported engines
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added propertyNameFull so composite PK/UK can be exported to Excel