### PR TITLE
HCK-9128: Handle indexes without name in CockroachDB

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -260,6 +260,10 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		createIndex(tableName, index, dbData, isParentActivated = true) {
+			if (!index.columns.length) {
+				return '';
+			}
+
 			const isUnique = index.unique && index.index_method === 'btree';
 			const name = wrapInQuotes(index.indxName);
 			const unique = isUnique ? ' UNIQUE' : '';

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -260,7 +260,9 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		createIndex(tableName, index, dbData, isParentActivated = true) {
-			if (!index.columns.length) {
+			const isNameEmpty = !index.indxName && index.ifNotExist;
+
+			if (!index.columns.length || isNameEmpty) {
 				return '';
 			}
 

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -574,7 +574,24 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Name",
 						"propertyKeyword": "indxName",
 						"propertyTooltip": "Optional, if not specified an automatic name will be assigned. Index name are needed to drop indexes and appear in error messages when a constraint is violated.",
-						"propertyType": "text"
+						"propertyType": "text",
+						"dependency": {
+							"key": "ifNotExist",
+							"value": false
+						}
+					},
+					{
+						"propertyName": "Name",
+						"propertyKeyword": "indxName",
+						"propertyTooltip": "",
+						"propertyType": "text",
+						"validation": {
+							"required": true
+						},
+						"dependency": {
+							"key": "ifNotExist",
+							"value": true
+						}
 					},
 					{
 						"propertyName": "Activated",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -576,8 +576,11 @@ making sure that you maintain a proper JSON format.
 						"propertyTooltip": "Optional, if not specified an automatic name will be assigned. Index name are needed to drop indexes and appear in error messages when a constraint is violated.",
 						"propertyType": "text",
 						"dependency": {
-							"key": "ifNotExist",
-							"value": false
+							"type": "not",
+							"values": {
+								"key": "ifNotExist",
+								"value": true
+							}
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -643,6 +643,10 @@ making sure that you maintain a proper JSON format.
 								"options": ["", "NULLS FIRST", "NULLS LAST"],
 								"propertyTooltip": "Specifies that nulls sort order"
 							}
+						},
+						"validation": {
+							"minLength": 1,
+							"required": true
 						}
 					},
 					{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9128" title="HCK-9128" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9128</a>  Handle indexes without name in all SQL-like targets, depending whether name is mandatory or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated validation of required fields in the "Create Index" script:
- index name is required only if the script contains "IF NOT EXIST"
- columns are required