### PR TITLE
HCK-10442: add config to properly convert hasMaxLength to Polyglot

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -212,6 +212,15 @@
 				"to": {
 					"mode": "point"
 				}
+			},
+			{
+				"from": {
+					"type": "varchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 10485760
+				}
 			}
 		]
 	}

--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -221,6 +221,15 @@
 				"to": {
 					"length": 10485760
 				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 10485760
+				}
 			}
 		]
 	}

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -52,6 +52,15 @@
 					"childType": "integer",
 					"mode": "bigint"
 				}
+			},
+			{
+				"from": {
+					"mode": "varchar",
+					"length": 10485760
+				},
+				"to": {
+					"hasMaxLength": true
+				}
 			}
 		]
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10442" title="HCK-10442" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10442</a>  Implement max length mapping for RDBMS-like database targets (cross-target conversion)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Add config to properly convert hasMaxLength to Polyglot