### PR TITLE
HCK-10527: added char and varbit length to max length conversion

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -61,6 +61,24 @@
 				"to": {
 					"hasMaxLength": true
 				}
+			},
+			{
+				"from": {
+					"mode": "char",
+					"length": 10485760
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"mode": "varbit",
+					"length": 10485760
+				},
+				"to": {
+					"hasMaxLength": true
+				}
 			}
 		]
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10527" title="HCK-10527" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10527</a>  [CockroachDB] Char/Varbit Max length. Incorrect conversion of max value to Polyglot (no max)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added char and varbit length to max length conversion