### PR TITLE
Revert "HCK-11091: Move the log of the start to the studio (#41)"

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -50,6 +50,14 @@ module.exports = {
 	},
 
 	applyToInstance(connectionInfo, logger, callback, app) {
+		logger.clear();
+		logger.log(
+			'info',
+			app.require('lodash').omit(connectionInfo, 'script', 'containerData'),
+			'connectionInfo',
+			connectionInfo.hiddenKeys,
+		);
+
 		const cockroachDBLogger = createLogger({
 			title: 'Apply to instance',
 			hiddenKeys: connectionInfo.hiddenKeys,

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { createLogger } = require('./helpers/loggerHelper');
 const cockroachDBService = require('./helpers/cockroachDBService');
 
@@ -13,6 +15,8 @@ module.exports = {
 		const sshService = app.require('@hackolade/ssh-service');
 
 		try {
+			logInfo('Test connection', connectionInfo, logger);
+
 			const cockroachDBLogger = createLogger({
 				title: 'Test connection instance log',
 				hiddenKeys: connectionInfo.hiddenKeys,
@@ -36,6 +40,8 @@ module.exports = {
 		const sshService = app.require('@hackolade/ssh-service');
 
 		try {
+			logInfo('Get databases', connectionInfo, logger);
+
 			const cockroachDBLogger = createLogger({
 				title: 'Get DB names',
 				hiddenKeys: connectionInfo.hiddenKeys,
@@ -63,6 +69,8 @@ module.exports = {
 		const sshService = app.require('@hackolade/ssh-service');
 
 		try {
+			logInfo('Get DB table names', connectionInfo, logger);
+
 			const cockroachDBLogger = createLogger({
 				title: 'Get DB collections names',
 				hiddenKeys: connectionInfo.hiddenKeys,
@@ -109,6 +117,8 @@ module.exports = {
 		const sshService = app.require('@hackolade/ssh-service');
 
 		try {
+			logger.log('info', data, 'Retrieve tables data:', data.hiddenKeys);
+
 			const cockroachDBLogger = createLogger({
 				title: 'Get DB collections data log',
 				hiddenKeys: data.hiddenKeys,
@@ -209,6 +219,11 @@ const prepareError = error => {
 	error = JSON.stringify(error, Object.getOwnPropertyNames(error));
 	error = JSON.parse(error);
 	return error;
+};
+
+const logInfo = (step, connectionInfo, logger) => {
+	logger.clear();
+	logger.log('info', connectionInfo, 'connectionInfo', connectionInfo.hiddenKeys);
 };
 
 const orderPackages = packages => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11091" title="HCK-11091" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-11091</a>  [Plugins] Remove the logging of system & connection information from every plugin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Temporarily revert to previous logging until the backward compatibility mechanism is implemented.