### PR TITLE
HCK-12495: Missing SQL statements in ALTER script

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -101,7 +101,6 @@ const getAlterCollectionsScriptDtos = ({
 		.concat(collection.properties?.entities?.properties?.added?.items)
 		.filter(Boolean)
 		.map(item => Object.values(item.properties)[0])
-		.filter(collection => !collection.compMod)
 		.flatMap(
 			getAddColumnScriptDtos({ app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions }),
 		);
@@ -109,13 +108,11 @@ const getAlterCollectionsScriptDtos = ({
 		.concat(collection.properties?.entities?.properties?.deleted?.items)
 		.filter(Boolean)
 		.map(item => Object.values(item.properties)[0])
-		.filter(collection => !collection.compMod)
 		.flatMap(getDeleteColumnScriptDtos(app));
 	const modifyColumnScriptDtos = []
 		.concat(collection.properties?.entities?.properties?.modified?.items)
 		.filter(Boolean)
 		.map(item => Object.values(item.properties)[0])
-		.filter(collection => !collection.compMod)
 		.flatMap(
 			getModifyColumnScriptDtos({ app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions }),
 		);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12495" title="HCK-12495" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12495</a>  [DeltaModel][CockroachDB]: Missing sql statements in alter script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

ALTER script misses SQL for added/deleted/modified fields when entity properties are modified. This happens because when an entity is modified, the delta model property has `compMod` in a changed field with the detected changes. The code filters out such fields.